### PR TITLE
Generalize app, framework and vendor file locations

### DIFF
--- a/src/ConsoleApp.php
+++ b/src/ConsoleApp.php
@@ -40,6 +40,8 @@ class ConsoleApp extends CraftConsoleApp
         if (!self::$instance) {
             throw new Exception('You must first set the instance via setInstance().');
         }
+
+        return self::$instance;
     }
 
     public static function setInstance(CApplication $app)

--- a/src/bootstrap-craft2.php
+++ b/src/bootstrap-craft2.php
@@ -66,8 +66,8 @@ ini_set('display_errors', 1);
 defined('YII_DEBUG') || define('YII_DEBUG', true);
 defined('YII_TRACE_LEVEL') || define('YII_TRACE_LEVEL', 3);
 
-require_once CRAFT_APP_PATH.'framework/yii.php';
-require_once CRAFT_APP_PATH.'vendor/autoload.php';
+require_once CRAFT_FRAMEWORK_PATH.'yii.php';
+require_once CRAFT_VENDOR_PATH.'autoload.php';
 
 Yii::$enableIncludePath = false;
 

--- a/src/bootstrap-craft2.php
+++ b/src/bootstrap-craft2.php
@@ -16,7 +16,10 @@ if (!isset($craftPath)) {
     }
 }
 
-$appPath = realpath($craftPath.'/app');
+if (!isset($appPath)) {
+    $appPath = realpath($craftPath.'/app');
+}
+
 
 defined('CRAFT_APP_PATH') || define('CRAFT_APP_PATH', $appPath.'/');
 defined('CRAFT_VENDOR_PATH') || define('CRAFT_VENDOR_PATH', CRAFT_APP_PATH.'vendor/');


### PR DESCRIPTION
This PR makes a couple changes to the bootstrap script to make it compatible with Craft installations with a custom directory structure. Notably, the way the bootstrap currently works is incompatible with installing the Craft core library and the Yii framework as a dependencies via Composer (which places them in `vendor/craftcms/cms/src` (`CRAFT_APP_PATH`) and `vendor/yiisoft/yii/framework` (`CRAFT_VENDOR_PATH`), respectively.

To allow for the customized structure, I modified the bootstrap file for Craft 2 to rely on the Craft global variables which are suited to the specific purpose of locating the app, framework and vendor code, rather than the assumptions that were being made that `craft/app` and `app/framework` would necessarily exist (which they don't in my project).

I made one additional change so that the `craft()` function was available from the console when running `bin/craft console`. There appears to be some code missing to return the instance of the Craft console app.